### PR TITLE
Expand consolidation plan with staged execution roadmap

### DIFF
--- a/pydantic-ai/CONSOLIDATION_PLAN.md
+++ b/pydantic-ai/CONSOLIDATION_PLAN.md
@@ -1,0 +1,94 @@
+# Consolidation Audit & Integration Plan
+
+This document captures the current state of the unified template and outlines the actions required to ensure the Claude sub-agent factory, agent runtimes, frontend, observability, and deployment workflows function cohesively after merging the two source repositories.
+
+## 1. Current Layout Overview
+
+The root `pydantic-ai/` bundle already pulls together the major subsystems:
+
+- **Automation / sub-agent factory** – Claude orchestration rules and workflows live in `CLAUDE.md`, guiding how agents are produced and structured end-to-end.【F:CLAUDE.md†L1-L198】
+- **Reference agents and examples** – canonical implementations (e.g., `agents/rag_agent`) plus runnable samples under `examples/` for regression and onboarding.【F:README.md†L3-L18】【F:agents/rag_agent/README.md†L1-L141】
+- **Full-stack runtime** – FastAPI backends and React frontend live beneath `services/`, complemented by Langfuse-ready production variants.【F:README.md†L3-L18】
+- **Pipelines & Deploy tooling** – RAG ingestion workers and Render/Terraform blueprints live under `pipelines/` and `deploy/`, with environment templates already defined for API, frontend, and pipeline services.【F:README.md†L13-L18】【F:deploy/blueprints/agent-api-env.env.example†L1-L119】【F:deploy/blueprints/frontend-env.env.example†L1-L66】【F:deploy/blueprints/rag-pipeline-env.env.example†L1-L89】
+
+This is a strong foundation, but several inconsistencies remain from the repo merge.
+
+## 2. Gaps & Conflicts Identified
+
+### 2.1 Backend dev server still references legacy path
+`services/backend/app_backend/agent_api.py` dynamically appends a `4_Pydantic_AI_Agent` folder that no longer exists in this layout, meaning the development FastAPI app cannot start without manual path hacks.【F:services/backend/app_backend/agent_api.py†L40-L72】 The production backend (`services/backend/agent_api_production`) already loads the in-repo `agent.py` module directly and should become the single source of truth.【F:services/backend/agent_api_production/agent_api.py†L1-L68】【F:services/backend/agent_api_production/agent.py†L1-L76】
+
+### 2.2 Example agent documentation references missing assets
+The semantic search agent README instructs users to `cp .env.example .env`, but the template file was not copied over from the original repo, leaving newcomers without a baseline environment map.【F:agents/rag_agent/README.md†L41-L52】
+
+### 2.3 Dependency duplication and drift
+There are two large `requirements.txt` files (dev vs production) with overlapping but not identical pins, increasing maintenance cost and risking divergent runtime behavior.【F:services/backend/app_backend/requirements.txt†L1-L98】【F:services/backend/agent_api_production/requirements.txt†L1-L152】 No shared `pyproject.toml` or constraints file is present at the template root, so unifying updates across services is difficult.
+
+### 2.4 Frontend/Base URL coupling is implicit
+The React frontend relies on `VITE_AGENT_ENDPOINT` and other env variables, but only the Render blueprint documents how to populate them. There is no local `.env.example` beside the frontend app, making dev setup less discoverable.【F:services/frontend/app_frontend/src/lib/api.ts†L5-L55】【F:deploy/blueprints/frontend-env.env.example†L11-L39】
+
+### 2.5 Pipeline configuration is siloed
+The RAG ingestion pipeline has its own env template but no documented hand-off showing how Supabase schemas or embeddings align with the agent’s expectations, risking drift between ingestion and query paths.【F:deploy/blueprints/rag-pipeline-env.env.example†L11-L89】
+
+## 3. Recommended Consolidation Steps
+
+### 3.1 Standardize agent packaging
+1. Promote `agents/rag_agent` as the canonical example and copy its runtime package (agent, prompts, tools, dependencies) into a reusable `packages/agents` namespace or publishable wheel.
+2. Generate a shared `.env.example` and `.env.test` for each agent using the variable set documented in the README to prevent missing assets.【F:agents/rag_agent/README.md†L41-L64】
+3. Document in `README.md` how newly generated agents from the Claude factory should be registered with the backend (e.g., import path conventions).
+
+### 3.2 Unify backend services
+1. Deprecate `services/backend/app_backend` or refactor it to import the same modules used by `agent_api_production`, eliminating the hard-coded `4_Pydantic_AI_Agent` path.【F:services/backend/app_backend/agent_api.py†L40-L50】
+2. Extract shared FastAPI dependencies (request models, Supabase helpers, streaming helpers) into `services/backend/common/` so both dev and production servers draw from one codebase.
+3. Replace duplicate `requirements.txt` files with a single `pyproject.toml` at `services/backend/` or the repo root plus optional `requirements-dev.txt` for local tooling.
+
+### 3.3 Surface environment configuration locally
+1. For each service (`services/backend/agent_api_production`, `services/frontend/app_frontend`, `pipelines/rag`), copy the Render blueprint env templates into colocated `.env.example` files so local developers discover them without reading `deploy/` first.【F:deploy/blueprints/agent-api-env.env.example†L8-L119】【F:deploy/blueprints/frontend-env.env.example†L11-L39】【F:deploy/blueprints/rag-pipeline-env.env.example†L11-L89】
+2. Add a top-level `ENVIRONMENT_SETUP.md` that explains how the Supabase project, PGVector schema, and Langfuse credentials are shared across backend, frontend, and pipeline layers.
+3. Confirm the frontend’s Vite config reads from `.env.local` and document a sample pointing at `http://localhost:8000/api/pydantic-agent` for local development.【F:services/frontend/app_frontend/src/lib/api.ts†L5-L55】
+
+### 3.4 Align ingestion ↔ query pipeline
+1. Document the Supabase schema, embedding dimensions, and collection names expected by the agent (e.g., the Mem0 config in `clients.py`) and ensure the pipeline writes identical metadata.【F:services/backend/agent_api_production/clients.py†L6-L116】
+2. Provide a minimal Supabase migration or SQL dump inside `deploy/sql/` that matches the agent’s runtime tables (messages, conversations, document rows) and reference it from both pipeline and backend READMEs.
+3. Create an integration test (could be a notebook) that ingests a sample document via the pipeline and verifies the agent can retrieve it through the backend.
+
+### 3.5 Observability & deployment glue
+1. Expand `deploy/start_configuration.py` docs to mention where the generated `render.yaml` should be committed or stored, and how it maps to the `.env` templates.【F:deploy/start_configuration.py†L1-L128】
+2. Ensure Langfuse configuration defaults are documented in backend and frontend env templates so toggling observability is straightforward.【F:deploy/blueprints/agent-api-env.env.example†L109-L119】
+3. Provide a `Makefile` or task runner that orchestrates `docker-compose` (if applicable), Vite dev server, backend API, and RAG worker to lower the barrier for end-to-end smoke tests.
+
+## 4. Execution Roadmap
+
+To convert the audit into action, organize work into three focused waves that reduce risk while keeping the reference agent runnable throughout.
+
+### Wave 0 – Baseline stabilization (Week 1)
+
+| Task | Owner | Inputs | Acceptance criteria |
+| --- | --- | --- | --- |
+| Replace the legacy `4_Pydantic_AI_Agent` import path with the production loader used in `services/backend/agent_api_production` | Backend | Section 3.2.1 | Dev FastAPI server starts without manual path edits; unit tests import the agent package in both dev and prod entry points |
+| Add `.env.example` and `.env.test` files for `agents/rag_agent` derived from the README and Render blueprints | Agents | Section 3.1.2 | `examples/rag_agent` launches with `poetry run uvicorn` after copying `.env.example`; README updated to reference new files |
+| Copy Render environment blueprints beside backend, frontend, and pipeline services (`services/backend`, `services/frontend`, `pipelines/rag`) | Frontend + Pipeline | Section 3.3.1 | Running `cp .env.example .env` in each service folder provides a complete variable list for local dev |
+
+### Wave 1 – Platform alignment (Weeks 2–3)
+
+| Task | Owner | Dependencies | Acceptance criteria |
+| --- | --- | --- | --- |
+| Consolidate backend dependencies under a single `pyproject.toml` (with extras for dev/test) and retire duplicate `requirements.txt` files | Backend | Wave 0 backend task | `poetry install` (or `uv pip sync`) yields identical environments for dev and prod APIs; CI lockfile generated |
+| Extract shared backend utilities into `services/backend/common/` and reference from both dev and prod apps | Backend | Wave 0 backend task | `pytest` passes; only one copy of clients, models, and helper functions remains |
+| Document Supabase schema and Langfuse usage in a new `ENVIRONMENT_SETUP.md` at repo root | Docs | Wave 0 env files | File explains how Supabase tables, embeddings, and observability keys are shared across services |
+
+### Wave 2 – Integration hardening (Weeks 4–5)
+
+| Task | Owner | Dependencies | Acceptance criteria |
+| --- | --- | --- | --- |
+| Provide migration SQL (or Prisma schema) aligning pipeline outputs with backend expectations | Pipeline | Wave 1 docs | Running migration produces tables consumed by the agent; instructions referenced from pipeline README |
+| Implement end-to-end ingestion→query smoke test (notebook or pytest) | QA | Pipeline migration | Test ingests sample docs and validates retrieval through backend endpoint; executed in CI |
+| Expand deployment docs (`deploy/start_configuration.py`, Render README) to map generated configs back to env templates | DevOps | Wave 1 docs | README details where to store generated `render.yaml`, how to supply env files, and how to enable Langfuse |
+
+### Continuous guardrails
+
+- **Change management** – Require updates to env templates and `ENVIRONMENT_SETUP.md` for any new configuration knob.
+- **Reference agent parity** – Keep `examples/rag_agent` wired into automated smoke tests to guarantee template integrity.
+- **Observability defaults** – Ensure Langfuse toggles remain off by default but documented for quick activation.
+
+Sequencing work in this fashion ensures the merged repository becomes a cohesive, reproducible template while keeping the canonical agent usable at every milestone.


### PR DESCRIPTION
## Summary
- replace the simple follow-up checklist with a phased execution roadmap that sequences work into stabilization, platform alignment, and integration waves
- spell out task ownership, dependencies, and acceptance criteria so each recommendation from the audit can be implemented predictably
- add continuous guardrails to keep the consolidated template healthy while the plan is executed

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d79136d00883319559db9420414976